### PR TITLE
TST add travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+
+rvm:
+  - "1.9.3"
+  - "2.0.0"
+
+gemfile:
+  - Gemfile


### PR DESCRIPTION
Adds travis support see: http://about.travis-ci.org/docs/user/getting-started/

Unfortunately at the moment there are 16 test failures in mocha, which I see on my local system too (perhaps I've not installed something correctly?)... See this failure report: https://travis-ci.org/hayd/emblem.js/jobs/10318315.

_Thanks for the gem!_
