### PR TITLE
change bindAttr to bind-attr

### DIFF
--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -548,7 +548,7 @@ preMustacheUnit
 nonMustacheUnit
   = tripleOpen / doubleOpen / hashStacheOpen / anyDedent / TERM
 
-// Support for div#id.whatever{ bindAttr whatever="asd" }
+// Support for div#id.whatever{ bind-attr whatever="asd" }
 rawMustacheSingle
  = singleOpen _ m:recursivelyParsedMustacheContent _ singleClose { m.escaped = true; return m; }
 inTagMustache 
@@ -735,7 +735,7 @@ boundAttributeValue
   / $boundAttributeValueChar+
 
 // With Ember-Handlebars variant, 
-// p class=something -> <p {{bindAttr class="something"}}></p>
+// p class=something -> <p {{bind-attr class="something"}}></p>
 boundAttribute
   = key:key '=' value:boundAttributeValue !'!' &{ return IS_EMBER; }
 { 

--- a/test/resources/ember-template-compiler.js
+++ b/test/resources/ember-template-compiler.js
@@ -241,7 +241,7 @@ Ember.Handlebars.precompile = function(string) {
     knownHelpers: {
       action: true,
       unbound: true,
-      bindAttr: true,
+      bind-attr: true,
       template: true,
       view: true,
       _triageMustache: true


### PR DESCRIPTION
I just updated ember and I started to get flooded with depreciation errors, apparently bind-attr is now favored over bindAttr. This patch seems to fix it for me, although I did not run any tests (not sure how).
