### PR TITLE
Print a better message if assertion fails

### DIFF
--- a/tests/support/integration-assertions.js
+++ b/tests/support/integration-assertions.js
@@ -1,4 +1,6 @@
 /*global QUnit*/
+
+import { w } from '../support/utils';
 import Emblem from '../../emblem';
 
 export function compilesTo( emblem, handlebars, message ) {
@@ -9,7 +11,12 @@ export function compilesTo( emblem, handlebars, message ) {
     if (messageEmblem.length > maxLenth) {
       messageEmblem = messageEmblem.slice(0,maxLenth) + '...';
     }
-    message = 'Expected "' + messageEmblem + '" to compile to "' + handlebars + '"';
+    message = w(
+      'compilesTo assertion failed:',
+      '\tEmblem:   "' + messageEmblem + '"',
+      '\tExpected: "' + handlebars + '"',
+      '\tActual:   "' + output + '"'
+    )
   }
   QUnit.push(output === handlebars, output, handlebars, message);
 };


### PR DESCRIPTION
This changes the assertion failure message from:
`Expected "| test" to compile to "<span>test</span>"`
to:
```
compilesTo assertion failed:
  Emblem:   "| test"
  Expected: "<span>test</span>"
  Actual:   "<p>test</p>"
```

In the browser QUnit already displays this information but if you run the tests using `npm test` then this change can be rather helpful.