### PR TITLE
Add support for block params

### DIFF
--- a/lib/mustache-parser.pegjs
+++ b/lib/mustache-parser.pegjs
@@ -4,15 +4,16 @@ start = newMustache
 // {
 //   name: string,
 //   attrs: array, (items look like 'class="abc"', 'tagName="xyz"', '(query-params foo=bar)', 'blah', '"quotedBlah"', etc)
+//   blockParams: array, (items are all strings like 'item', 'foo', etc.)
 //   modifier: '?' or '!' (optional),
 // }
 // upstream parsers will optionally add an `isEscaped:true` property
-newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAttr*) {
+newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAttr*) blockParams:m_blockParams? {
   attrs = attrs.concat(name.shorthands);
-
   var ret = {
     name: name.name,
-    attrs: attrs
+    attrs: attrs,
+    blockParams: blockParams
   };
   if (name.modifier) {
     ret.modifier = name.modifier;
@@ -20,6 +21,14 @@ newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAtt
 
   return ret;
 }
+
+m_blockParams = m_blockStart m_* params:blockParamNames+ {
+  return params;
+}
+
+m_blockStart = "as"
+
+blockParamNames = newMustacheAttrValue
 
 // open bracket followed by mustache attrs on separate lines followed by close bracket.
 // We use the '&' syntax to avoid capturing the close bracket because the upstream parser
@@ -85,7 +94,7 @@ m_keyValue = attrName:newMustacheAttrName m_* '=' m_* attrValue:newMustacheAttrV
 
 newMustacheAttrName = $newMustacheNameChar+
 
-newMustacheAttrValue = !m_invalidValueStartChar v:(m_quotedString / m_valuePath / m_parenthetical) m_* {
+newMustacheAttrValue = !(m_invalidValueStartChar / m_blockStart) v:(m_quotedString / m_valuePath / m_parenthetical) m_* {
   return v;
 }
 

--- a/lib/mustache-parser.pegjs
+++ b/lib/mustache-parser.pegjs
@@ -22,7 +22,7 @@ newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAtt
   return ret;
 }
 
-m_blockParams = m_blockStart m_* params:blockParamNames+ {
+m_blockParams = m_blockStart m_* "|" m_* params:blockParamNames+ "|" {
   return params;
 }
 

--- a/lib/mustache-parser.pegjs
+++ b/lib/mustache-parser.pegjs
@@ -22,13 +22,13 @@ newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAtt
   return ret;
 }
 
-m_blockParams = m_blockStart m_* "|" m_* params:blockParamNames+ "|" {
+m_blockParams = m_blockStart m_* params:blockParamName+ "|" {
   return params;
 }
 
-m_blockStart = "as"
+m_blockStart = "as" m_* "|"
 
-blockParamNames = newMustacheAttrValue
+blockParamName = newMustacheAttrValue
 
 // open bracket followed by mustache attrs on separate lines followed by close bracket.
 // We use the '&' syntax to avoid capturing the close bracket because the upstream parser

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -134,10 +134,15 @@
     var escaped    = mustache.isEscaped;
     var mustacheContent = mustache.name;
     var mustacheAttrs = mustache.attrs;
+    var mustacheBlockParams = mustache.blockParams;
 
     if (mustacheAttrs.length) {
       var attrs = coalesceAttrs(mustacheAttrs);
       mustacheContent += ' ' + attrs.join(' ');
+    }
+
+    if (mustacheBlockParams) {
+      mustacheContent += ' as |' + mustacheBlockParams.join(' ') + '|';
     }
 
     if (mustache.isViewHelper) {

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -41,15 +41,20 @@ QUnit.module("mustache: block params");
 
 test("anything after 'as' goes in block params", function(){
   var emblem = w(
-    "= each foos as foo"
+    "= each foos as |foo|"
   );
   compilesTo(emblem,
     '{{each foos as |foo|}}');
 });
 
+test("spaces between '||' and params are removed", function(){
+  compilesTo("= each foos as |foo|", '{{each foos as |foo|}}');
+  compilesTo("= each foos as | foo |", '{{each foos as |foo|}}');
+});
+
 test("multiple words work too", function(){
   var emblem = w(
-    "= my-helper as foo bar"
+    "= my-helper as |foo bar|"
   );
   compilesTo(emblem,
     '{{my-helper as |foo bar|}}');
@@ -57,7 +62,7 @@ test("multiple words work too", function(){
 
 test("block form works for the 'with' helper", function(){
   var emblem = w(
-    "= with car.manufacturer as make",
+    "= with car.manufacturer as |make|",
     "  p {{make.name}}"
   );
   compilesTo(emblem,
@@ -66,7 +71,7 @@ test("block form works for the 'with' helper", function(){
 
 test("block form works for components", function(){
   var emblem = w(
-    "= my-component as item",
+    "= my-component as |item|",
     "  p {{item.name}}"
   );
   compilesTo(emblem,

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -55,13 +55,22 @@ test("multiple words work too", function(){
     '{{my-helper as |foo bar|}}');
 });
 
-test("block form works", function(){
+test("block form works for the 'with' helper", function(){
   var emblem = w(
-    "= each foos as foo",
-    "  p each content"
+    "= with car.manufacturer as make",
+    "  p {{make.name}}"
   );
   compilesTo(emblem,
-    '{{#each foos as |foo|}}<p>each content</p>{{/each}}');
+    '{{#with car.manufacturer as |make|}}<p>{{make.name}}</p>{{/with}}');
+});
+
+test("block form works for components", function(){
+  var emblem = w(
+    "= my-component as item",
+    "  p {{item.name}}"
+  );
+  compilesTo(emblem,
+    '{{#my-component as |item|}}<p>{{item.name}}</p>{{/my-component}}');
 });
 
 QUnit.module("mustache: capitalized line-starter");

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -37,6 +37,33 @@ test("nested combo syntax", function(){
     '<ul>{{#each items}}<li>{{foo}}</li>{{/each}}</ul>');
 });
 
+QUnit.module("mustache: block params");
+
+test("anything after 'as' goes in block params", function(){
+  var emblem = w(
+    "= each foos as foo"
+  );
+  compilesTo(emblem,
+    '{{each foos as |foo|}}');
+});
+
+test("multiple words work too", function(){
+  var emblem = w(
+    "= my-helper as foo bar"
+  );
+  compilesTo(emblem,
+    '{{my-helper as |foo bar|}}');
+});
+
+test("block form works", function(){
+  var emblem = w(
+    "= each foos as foo",
+    "  p each content"
+  );
+  compilesTo(emblem,
+    '{{#each foos as |foo|}}<p>each content</p>{{/each}}');
+});
+
 QUnit.module("mustache: capitalized line-starter");
 
 test("should invoke `view` helper by default", function(){

--- a/tests/unit/mustache-parser-test.js
+++ b/tests/unit/mustache-parser-test.js
@@ -288,7 +288,7 @@ test("conditional modifier", function(assert) {
 });
 
 test('block params', function(assert){
-  var text = 'frank foo=bar boo=far as steve';
+  var text = 'frank foo=bar boo=far as |steve|';
 
   assert.deepEqual( parse(text), {
     name: 'frank',
@@ -298,7 +298,7 @@ test('block params', function(assert){
 });
 
 test('multiple block params', function(assert){
-  var text = 'frank foo=bar boo=far as steve dave';
+  var text = 'frank foo=bar boo=far as |steve dave|';
 
   assert.deepEqual( parse(text), {
     name: 'frank',

--- a/tests/unit/mustache-parser-test.js
+++ b/tests/unit/mustache-parser-test.js
@@ -10,7 +10,8 @@ test('capitalized start', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'App.Funview',
-    attrs: []
+    attrs: [],
+    blockParams: null
   });
 });
 
@@ -19,7 +20,8 @@ test('lowercase start', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: []
+    attrs: [],
+    blockParams: null
   });
 });
 
@@ -28,7 +30,8 @@ test('lowercase unquoted attr value', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['foo=bar']
+    attrs: ['foo=bar'],
+    blockParams: null
   });
 });
 
@@ -37,7 +40,8 @@ test('attrs with spaces', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['foo=bar', 'boo=far']
+    attrs: ['foo=bar', 'boo=far'],
+    blockParams: null
   });
 });
 
@@ -46,7 +50,8 @@ test('multiple attrs', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['foo=bar', 'boo=far']
+    attrs: ['foo=bar', 'boo=far'],
+    blockParams: null
   });
 });
 
@@ -55,7 +60,8 @@ test('lowercase double-quoted attr value', function(assert){
 
   assert.deepEqual( parse(doubleQuote), {
     name: 'input',
-    attrs: ['placeholder="\'100% /^%&*()x12#"']
+    attrs: ['placeholder="\'100% /^%&*()x12#"'],
+    blockParams: null
   });
 });
 
@@ -64,7 +70,8 @@ test('lowercase single-quoted attr value', function(assert){
 
   assert.deepEqual( parse(singleQuote), {
     name: 'input',
-    attrs: ["placeholder='\"100% /^%&*()x12#'"]
+    attrs: ["placeholder='\"100% /^%&*()x12#'"],
+    blockParams: null
   });
 });
 
@@ -72,7 +79,8 @@ test('attr value with underscore', function(assert){
   var text = 'input placeholder=cat_name';
   assert.deepEqual( parse(text), {
     name: 'input',
-    attrs: ["placeholder=cat_name"]
+    attrs: ["placeholder=cat_name"],
+    blockParams: null
   });
 });
 
@@ -80,7 +88,8 @@ test('attr value is subexpression', function(assert){
   var text = 'echofun fun=(equal 1 1)';
   assert.deepEqual( parse(text), {
     name: 'echofun',
-    attrs: ["fun=(equal 1 1)"]
+    attrs: ["fun=(equal 1 1)"],
+    blockParams: null
   });
 });
 
@@ -89,7 +98,8 @@ test('attr value is complex subexpression', function(assert){
   assert.deepEqual( parse(text), {
     name: 'echofun',
     attrs: ["true", '(hello how="are" you=false)', '1', 'not=true',
-            'fun=(equal "ECHO hello" (echo (hello)))', 'win="yes"']
+            'fun=(equal "ECHO hello" (echo (hello)))', 'win="yes"'],
+    blockParams: null
   });
 });
 
@@ -99,11 +109,13 @@ test('attr value is empty string', function(assert){
 
   assert.deepEqual( parse(singleQuote), {
     name: 'input',
-    attrs: ["placeholder=''"]
+    attrs: ["placeholder=''"],
+    blockParams: null
   });
   assert.deepEqual( parse(doubleQuote), {
     name: 'input',
-    attrs: ['placeholder=""']
+    attrs: ['placeholder=""'],
+    blockParams: null
   });
 });
 
@@ -112,7 +124,8 @@ test('query-params', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['(query-params groupId=defaultGroup.id)']
+    attrs: ['(query-params groupId=defaultGroup.id)'],
+    blockParams: null
   });
 });
 
@@ -121,7 +134,8 @@ test('nested query-params', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['(query-params groupId=defaultGroup.id (more-qp x=foo))']
+    attrs: ['(query-params groupId=defaultGroup.id (more-qp x=foo))'],
+    blockParams: null
   });
 });
 
@@ -133,7 +147,8 @@ test('mixed query-params and key-value attrs', function(assert){
             'fob=bob',
             '(qp-2 dog=fog)',
             'dab=tab'],
-    name: 'frank'
+    name: 'frank',
+    blockParams: null
   });
 });
 
@@ -142,7 +157,8 @@ test('mustache name with dash', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'link-to',
-    attrs: ['foo=bar']
+    attrs: ['foo=bar'],
+    blockParams: null
   });
 });
 
@@ -151,7 +167,8 @@ test('mustache name with "/"', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'navigation/button-list',
-    attrs: []
+    attrs: [],
+    blockParams: null
   });
 });
 
@@ -166,7 +183,8 @@ test('mustache with quoted param', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'link-to',
-    attrs: ['"abc.def"']
+    attrs: ['"abc.def"'],
+    blockParams: null
   });
 });
 
@@ -175,7 +193,8 @@ test('mustache with unquoted param', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'link-to',
-    attrs: ['dog']
+    attrs: ['dog'],
+    blockParams: null
   });
 });
 
@@ -184,7 +203,8 @@ test('mustache with multiple params', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'link-to',
-    attrs: ['"dog.tag"', 'dog']
+    attrs: ['"dog.tag"', 'dog'],
+    blockParams: null
   });
 });
 
@@ -193,7 +213,8 @@ test('mustache with shorthand % syntax', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['tagName="span"']
+    attrs: ['tagName="span"'],
+    blockParams: null
   });
 });
 
@@ -202,7 +223,8 @@ test('mustache with shorthand # syntax', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['elementId="id-name"']
+    attrs: ['elementId="id-name"'],
+    blockParams: null
   });
 });
 
@@ -211,7 +233,8 @@ test('mustache with shorthand . syntax with required space', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['class="class-name"']
+    attrs: ['class="class-name"'],
+    blockParams: null
   });
 });
 
@@ -221,7 +244,8 @@ test('mustache with multiple classes', function(assert){
   assert.deepEqual( parse(text), {
     name: 'frank',
     attrs: ['class="class-name1"',
-            'class="class-name2"']
+            'class="class-name2"'],
+    blockParams: null
   });
 });
 
@@ -230,7 +254,8 @@ test('mustache with multiple shorthands', function(assert){
 
   assert.deepEqual( parse(text), {
     name: 'frank',
-    attrs: ['tagName="span"', 'elementId="my-id"', 'class="class-name"']
+    attrs: ['tagName="span"', 'elementId="my-id"', 'class="class-name"'],
+    blockParams: null
   });
 });
 
@@ -246,7 +271,8 @@ test("bang modifier", function(assert) {
   assert.deepEqual( parse(text), {
     name: 'foo',
     attrs: [],
-    modifier: '!'
+    modifier: '!',
+    blockParams: null
   });
 });
 
@@ -256,6 +282,28 @@ test("conditional modifier", function(assert) {
   assert.deepEqual( parse(text), {
     name: 'foo',
     attrs: [],
-    modifier: '?'
+    modifier: '?',
+    blockParams: null
   });
 });
+
+test('block params', function(assert){
+  var text = 'frank foo=bar boo=far as steve';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['foo=bar', 'boo=far'],
+    blockParams: ['steve']
+  });
+});
+
+test('multiple block params', function(assert){
+  var text = 'frank foo=bar boo=far as steve dave';
+
+  assert.deepEqual( parse(text), {
+    name: 'frank',
+    attrs: ['foo=bar', 'boo=far'],
+    blockParams: ['steve', 'dave']
+  });
+});
+


### PR DESCRIPTION
```
=each collection as |item index|
   p {{item.name}}
```
 becomes 

```
{{#each collection as |item index|}}
  <p>{{item.name}}</p>
{{/each}}
```

For now I'm having the mustache parser output block params as `null` rather than an empty array, but that's easily changed.  Comments welcome; this is the first time I've messed with a parser. 