### PR TITLE
Added new attribute binding syntax from 1.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "qunit": "1.17.1",
     "loader.js": "ember-cli/loader.js",
-    "ember": "1.9.1",
+    "ember": "1.11.3",
     "jquery": "~2.1.3"
   }
 }

--- a/lib/ast-builder.js
+++ b/lib/ast-builder.js
@@ -55,6 +55,14 @@ var builder = {
     };
   },
 
+  generateAssignedMustache: function(content, key) {
+    return {
+      type: 'assignedMustache',
+      content: content,
+      key: key
+    };
+  },
+
   mustache: function(content, escaped){
     var node = this.generateMustache(content, escaped);
     this.currentNode.childNodes.push(node);

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -187,6 +187,16 @@
     return builder.generateText(content);
   }
 
+  /**
+    Splits a value string into separate parts,
+    then generates a classBinding for each part.
+  */
+  function splitValueIntoClassBindings(value) {
+    return value.split(' ').map(function(v){
+      return builder.generateClassNameBinding(v);
+    });
+  }
+
   function parseInHtml(h, inTagMustaches, fullAttributes) {
     var tagName = h[0] || 'div',
         shorthandAttributes = h[1] || [],
@@ -215,6 +225,7 @@
 
     for(i = 0; i < fullAttributes.length; ++i) {
       var currentAttr = fullAttributes[i];
+
       if (Array.isArray(currentAttr) && typeof currentAttr[0] === 'string') {  // a "normalAttribute", [attrName, attrContent]
         if (currentAttr.length) { // a boolean false attribute will be []
 
@@ -672,7 +683,7 @@ shorthandAttributes
 }
 
 fullAttribute
-  = ' '+ a:(actionAttribute / booleanAttribute / boundAttribute / rawMustacheAttribute / normalAttribute)
+  = ' '+ a:(actionAttribute / booleanAttribute / boundAttributeWithSingleMustache/ boundAttribute / rawMustacheAttribute / normalAttribute)
 {
   return a || [];
 }
@@ -736,17 +747,54 @@ boundAttributeValue
   = '{' _ value:$(boundAttributeValueChar / ' ')+ _ '}' { return value.replace(/ *$/, ''); }
   / $boundAttributeValueChar+
 
+/**
+  Catchall when single mustache is assigned to a key.
+  This excludes assigning the inline shorthand foo:bar
+  thing={ whatever you want 'to' do }
+
+  Ignores:
+  thing={ foo:bar }
+*/
+// Any character including strings
+allCharactersExceptColonSyntax
+  = $((nmchar / whitespace / singleQuoteString / doubleQuoteString)*)
+
+nonQuoteChars
+  = [^"']
+
+singleQuoteString
+  = $(['] (nonQuoteChars / ["])* ['])
+
+doubleQuoteString
+  = $(["] (nonQuoteChars / ['])* ["])
+
+boundAttributeWithSingleMustache
+  = key:key '=' singleOpen _ value:allCharactersExceptColonSyntax _ singleClose
+{
+  value = value.trim();
+
+  // Class logic needs to be coalesced, except if it is an inline if statement
+  if (key === 'class') {
+    if (value.indexOf('if') === 0) {
+      return builder.generateClassNameBinding(value);
+    } else {
+      return splitValueIntoClassBindings(value);
+    }
+  } else {
+    return builder.generateAssignedMustache(value, key);
+  }
+}
+
+
 // With Ember-Handlebars variant,
 // p class=something -> <p {{bindAttr class="something"}}></p>
 boundAttribute
   = key:key '=' value:boundAttributeValue !'!'
 {
   if (key === 'class') {
-    return value.split(' ').map(function(v){
-      return builder.generateClassNameBinding(v);
-    });
+    return splitValueIntoClassBindings(value);
   } else {
-    return [builder.generateMustache('bind-attr ' + key + '=' + value)];
+    return builder.generateAssignedMustache(value, key);
   }
 }
 

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -757,7 +757,7 @@ boundAttributeValue
 */
 // Any character including strings
 allCharactersExceptColonSyntax
-  = $((nmchar / whitespace / singleQuoteString / doubleQuoteString)*)
+  = $((nmchar / [.()] / whitespace / singleQuoteString / doubleQuoteString)*)
 
 nonQuoteChars
   = [^"']

--- a/lib/template-compiler.js
+++ b/lib/template-compiler.js
@@ -22,10 +22,47 @@ function pushContent(compiler, content) {
   compiler._content.push(content);
 }
 
-var classNameBindings, hasBoundClassNameBindings;
+/**
+  Wrap an string in mustache
+  @param {Array} names
+  @return {Array}
+*/
+function wrapMustacheStrings(names) {
+  return names.map(function(name) { return '{{' + name + '}}'; });
+}
+
+/**
+  Map a colon syntax string to inline if syntax.
+  @param {String} Name
+  @return {String}
+*/
+function mapColonSyntax(name) {
+  var parts = name.split(':');
+
+  // First item will always be wrapped in single quotes (since we need at least one result for condition)
+  parts[1] = singleQuoteString(parts[1]);
+
+  // Only wrap second option if it exists
+  if (parts[2])
+    parts[2] = singleQuoteString(parts[2]);
+
+  parts.unshift('if');
+
+  return parts.join(' ');
+}
+
+/**
+  Wrap an string in single quotes
+  @param {String} value
+  @return {String}
+*/
+function singleQuoteString(value) {
+  return "'" + value + "'";
+}
+
+var boundClassNames, unboundClassNames;
 
 var compiler = {
-
   startProgram: function(){},
   endProgram: function(){},
 
@@ -58,23 +95,53 @@ var compiler = {
   },
 
   openClassNameBindings: function(){
-    classNameBindings = [];
-    hasBoundClassNameBindings = false;
+    boundClassNames = [];
+    unboundClassNames = [];
   },
 
+  /**
+    Add a class name binding
+    @param {String} name
+  */
   classNameBinding: function(name) {
-    if (!hasBoundClassNameBindings) {
-      hasBoundClassNameBindings = (name.indexOf(':') !== 0);
+    var isBoundAttribute = name[0] !== ':';
+
+    if (isBoundAttribute) {
+      var isColonSyntax = name.indexOf(':') > -1;
+      if (isColonSyntax) {
+        name = mapColonSyntax(name);
+      }
+      boundClassNames.push(name);
+    } else {
+      name = name.slice(1);
+      unboundClassNames.push(name);
     }
-    classNameBindings.push(name);
   },
 
-  closeClassNameBindings: function(){
-    if (hasBoundClassNameBindings) {
-      pushContent(this, ' {{bind-attr class='+string(classNameBindings.join(' '))+'}}');
-    } else {
-      pushContent(this, ' class='+string(classNameBindings.map(function(c){ return c.slice(1); }).join(' ')));
-    }
+  /**
+    Group all unbound classes into a single string
+    Wrap each binding in mustache
+  */
+  closeClassNameBindings: function() {
+    var unboundClassString = unboundClassNames.join(' ');
+    var mustacheString = wrapMustacheStrings(boundClassNames).join(' ');
+    var results = [unboundClassString, mustacheString];
+
+    // Remove any blank strings
+    results = results.filter(function (i) {
+      return i !== "";
+    });
+    results = results.join(' ');
+
+    // We only need to wrap the results in quotes if we have at least one unbound or more than 1 bound attributes
+    var wrapInString = unboundClassString.length > 0 || boundClassNames.length > 1;
+
+    if (wrapInString)
+      results = string(results);
+    else if (results.length === 0)
+      results = '\"\"';
+
+    pushContent(this, ' class=' + results);
   },
 
   startBlock: function(content){
@@ -94,6 +161,15 @@ var compiler = {
     } else {
       pushContent(this, prepend + '{{{' + content + '}}}');
     }
-  }
+  },
 
+  /**
+    Special syntax for assigning mustache to a key
+    @param {String} content
+    @param {String} key
+  */
+  assignedMustache: function(content, key) {
+    var prepend = this._insideElement ? ' ' : '';
+    pushContent(this, prepend + key + '=' + '{{' + content + '}}');
+  }
 };

--- a/lib/template-visitor.js
+++ b/lib/template-visitor.js
@@ -65,6 +65,9 @@ var visitor = {
 
   mustache: function(node, opcodes){
     opcodes.push(['mustache', [node.content, node.escaped]]);
-  }
+  },
 
+  assignedMustache: function(node, opcodes) {
+    opcodes.push(['assignedMustache', [node.content, node.key]]);
+  }
 };

--- a/tests/integration/attributes-test.js
+++ b/tests/integration/attributes-test.js
@@ -138,12 +138,12 @@ test("when literal class is used", function() {
 
 test("when ember expression is used with variable", function() {
   compilesTo('p.foo class=bar',
-             '<p {{bind-attr class=":foo bar"}}></p>');
+             '<p class="foo {{bar}}"></p>');
 });
 
 test("when ember expression is used with variable in braces", function() {
   compilesTo('p.foo class={ bar }',
-             '<p {{bind-attr class=":foo bar"}}></p>');
+             '<p class="foo {{bar}}"></p>');
 });
 
 test("when ember expression is used with constant in braces", function() {
@@ -153,7 +153,7 @@ test("when ember expression is used with constant in braces", function() {
 
 test("when ember expression is used with constant and variable in braces", function() {
   compilesTo('p.foo class={ :bar bar }',
-             '<p {{bind-attr class=":foo :bar bar"}}></p>');
+             '<p class="foo bar {{bar}}"></p>');
 });
 
 QUnit.module("attributes: shorthand: mustache DOM attribute shorthand");
@@ -202,11 +202,11 @@ QUnit.module("attributes: bound and unbound");
 
 test("path with dot", function(){
   var emblem = 'iframe src=post.pdfAttachment';
-  compilesTo(emblem, '<iframe {{bind-attr src=post.pdfAttachment}}></iframe>');
+  compilesTo(emblem, '<iframe src={{post.pdfAttachment}}></iframe>');
 
   emblem = 'iframe src=post.pdfAttachmentUrl width="96%" height="400" view="FitV" frameborder="0" style="z-index: 0 !important;"';
   compilesTo(emblem,
-                    '<iframe {{bind-attr src=post.pdfAttachmentUrl}} width="96%" height="400" view="FitV" frameborder="0" style="z-index: 0 !important;"></iframe>');
+                    '<iframe src={{post.pdfAttachmentUrl}} width="96%" height="400" view="FitV" frameborder="0" style="z-index: 0 !important;"></iframe>');
 });
 
 test('mustache in attribute', function(){
@@ -226,7 +226,7 @@ test('mustache attribute value has comma', function(){
 
 test("mustache class binding", function(){
   var emblem = 'iframe.foo class=dog';
-  compilesTo(emblem, '<iframe {{bind-attr class=":foo dog"}}></iframe>');
+  compilesTo(emblem, '<iframe class="foo {{dog}}"></iframe>');
 });
 
 test("numbers in shorthand", function() {
@@ -247,4 +247,61 @@ test("booleans with and without quoting", function(){
   compilesTo('foo what=false', '{{foo what=false}}');
   compilesTo('foo what="false"', '{{foo what="false"}}');
   compilesTo("foo what='false'", '{{foo what=\'false\'}}');
+});
+
+test("bound attributes from within strings", function() {
+  var emblem = 'div style="width: {{userProvidedWidth}}px;"';
+  compilesTo(emblem, '<div style="width: {{userProvidedWidth}}px;"></div>');
+});
+
+QUnit.module("attributes with inline if");
+
+test("with attribute and bound values", function() {
+  var emblem = 'div style={ if isActive foo bar }';
+  compilesTo(emblem, '<div style={{if isActive foo bar}}></div>');
+});
+
+test("with attribute", function() {
+  var emblem = 'a href={ if isActive \'http://google.com\' \'http://bing.com\' }';
+  compilesTo(emblem, '<a href={{if isActive \'http://google.com\' \'http://bing.com\'}}></a>');
+});
+
+test("with attribute and bound values", function() {
+  var emblem = 'a href={ if isActive google bing }';
+  compilesTo(emblem, '<a href={{if isActive google bing}}></a>');
+});
+
+test("unbound attributes", function() {
+  var emblem = 'div class={ if isActive \'foo\' \'bar\' }';
+  compilesTo(emblem, '<div class={{if isActive \'foo\' \'bar\'}}></div>');
+});
+
+test("bound attributes", function() {
+  var emblem = 'div class={ if isActive foo bar }';
+  compilesTo(emblem, '<div class={{if isActive foo bar}}></div>');
+});
+
+test("mixed attributes", function() {
+  var emblem = 'div class={ if isActive \'foo\' bar }';
+  compilesTo(emblem, '<div class={{if isActive \'foo\' bar}}></div>');
+});
+
+test("unbound attributes with full quote", function() {
+  var emblem = 'div class={ if isActive \"foo\" bar }';
+  compilesTo(emblem, '<div class={{if isActive \"foo\" bar}}></div>');
+});
+
+test("one unbound option", function() {
+  var emblem = 'div class={ if isActive \"foo\" }';
+  compilesTo(emblem, '<div class={{if isActive \"foo\"}}></div>');
+});
+
+test("one bound option", function() {
+  var emblem = 'div class={ if isActive foo }';
+  compilesTo(emblem, '<div class={{if isActive foo}}></div>');
+});
+
+test("within a string", function() {
+  var emblem = 'div style="{{ if isActive \"15\" \"25\" }}px"';
+  compilesTo(emblem, '<div style=\"{{if isActive \\"15\\" \\"25\\" }}px\"></div>');
 });

--- a/tests/integration/attributes-test.js
+++ b/tests/integration/attributes-test.js
@@ -1,5 +1,6 @@
 /*global QUnit*/
 
+import { w } from '../support/utils';
 import { compilesTo } from '../support/integration-assertions';
 
 QUnit.module("attributes: shorthand");
@@ -304,4 +305,20 @@ test("one bound option", function() {
 test("within a string", function() {
   var emblem = 'div style="{{ if isActive \"15\" \"25\" }}px"';
   compilesTo(emblem, '<div style=\"{{if isActive \\"15\\" \\"25\\" }}px\"></div>');
+});
+
+test("with dot params", function() {
+  var emblem = w(
+    "li class={ if content.length 'just-one' }",
+    "  |Thing"
+  );
+  compilesTo(emblem, "<li class={{if content.length 'just-one'}}>Thing</li>");
+});
+
+test("mixed with subexpressions", function() {
+  var emblem = w(
+    "li class={ if (has-one content.length) 'just-one' }",
+    "  |Thing"
+  );
+  compilesTo(emblem, "<li class={{if (has-one content.length) 'just-one'}}>Thing</li>");
 });

--- a/tests/integration/bind-attr-test.js
+++ b/tests/integration/bind-attr-test.js
@@ -3,42 +3,62 @@
 import { w } from '../support/utils';
 import { compilesTo } from '../support/integration-assertions';
 
-QUnit.module("bind-attr behavior for unquoted attribute values");
+QUnit.module("binding behavior for unquoted attribute values");
 
 test("basic", function() {
   var emblem = 'p class=foo';
-  compilesTo(emblem, '<p {{bind-attr class="foo"}}></p>');
+  compilesTo(emblem, '<p class={{foo}}></p>');
 });
 
 test("basic w/ underscore", function() {
   var emblem = 'p class=foo_urns';
-  compilesTo(emblem, '<p {{bind-attr class="foo_urns"}}></p>');
+  compilesTo(emblem, '<p class={{foo_urns}}></p>');
 });
 
 test("subproperties", function() {
   var emblem = 'p class=foo._death.woot';
-  compilesTo(emblem, '<p {{bind-attr class="foo._death.woot"}}></p>');
+  compilesTo(emblem, '<p class={{foo._death.woot}}></p>');
 });
 
 test("multiple", function() {
   var emblem = 'p class=foo id="yup" data-thinger=yeah Hooray';
-  compilesTo(emblem, '<p id="yup" {{bind-attr data-thinger=yeah}} {{bind-attr class="foo"}}>Hooray</p>');
+  compilesTo(emblem, '<p id="yup" data-thinger={{yeah}} class={{foo}}>Hooray</p>');
 });
 
-test("class bind-attr special syntax", function() {
+test("class special syntax with 2 vals", function() {
   var emblem = 'p class=foo:bar:baz';
-  compilesTo(emblem, '<p {{bind-attr class="foo:bar:baz"}}></p>');
+  compilesTo(emblem, '<p class={{if foo \'bar\' \'baz\'}}></p>');
 });
 
-test("class bind-attr braced syntax w/ underscores and dashes", function() {
-  compilesTo('p class={f-oo:bar :b_az}', '<p {{bind-attr class="f-oo:bar :b_az"}}></p>');
-  compilesTo('p class={ f-oo:bar :b_az }', '<p {{bind-attr class="f-oo:bar :b_az"}}></p>');
-  compilesTo('p class={ f-oo:bar :b_az } Hello', '<p {{bind-attr class="f-oo:bar :b_az"}}>Hello</p>');
+test("class special syntax with only 2nd val", function() {
+  var emblem = 'p class=foo::baz';
+  compilesTo(emblem, '<p class={{if foo \'\' \'baz\'}}></p>');
+});
+
+test("class special syntax with only 1st val", function() {
+  var emblem = 'p class=foo:baz';
+  compilesTo(emblem, '<p class={{if foo \'baz\'}}></p>');
+});
+
+test("Inline binding with mixed classes", function() {
+  var emblem = ".notice class={ test::active }";
+  compilesTo(emblem, '<div class=\"notice {{if test \'\' \'active\'}}\"></div>');
+});
+
+test("class braced syntax w/ underscores and dashes", function() {
+  compilesTo('p class={f-oo:bar :b_az}', '<p class="b_az {{if f-oo \'bar\'}}"></p>');
+  compilesTo('p class={ f-oo:bar :b_az }', '<p class="b_az {{if f-oo \'bar\'}}"></p>');
+  compilesTo('p class={ f-oo:bar :b_az } Hello', '<p class="b_az {{if f-oo \'bar\'}}">Hello</p>');
   var emblem = w(
     ".input-prepend class={ filterOn:input-append }",
     "  span.add-on"
   );
-  compilesTo(emblem, '<div {{bind-attr class=":input-prepend filterOn:input-append"}}><span class="add-on"></span></div>');
+  compilesTo(emblem, '<div class="input-prepend {{if filterOn \'input-append\'}}"><span class="add-on"></span></div>');
+});
+
+test("multiple bindings with inline conditionals", function() {
+  var emblem = "button class={ thing1:active thing2:alert }";
+  compilesTo(emblem, '<button class=\"{{if thing1 \'active\'}} {{if thing2 \'alert\'}}\"></button>');
 });
 
 test("exclamation modifier (ember)", function() {

--- a/tests/integration/colon-separator-test.js
+++ b/tests/integration/colon-separator-test.js
@@ -53,8 +53,7 @@ test("with text terminator", function() {
 });
 
 test("test from heartsentwined", function() {
-  compilesTo('li data-foo=bar: a',
-                    '<li {{bind-attr data-foo=bar}}><a></a></li>');
+  compilesTo('li data-foo=bar: a', '<li data-foo={{bar}}><a></a></li>');
   compilesTo("li data-foo='bar': a", '<li data-foo="bar"><a></a></li>');
 });
 
@@ -62,7 +61,7 @@ test("mixture of colon and indentation", function() {
   var emblem;
   emblem = "li data-foo=bar: a\n  baz";
   return compilesTo(emblem,
-                           '<li {{bind-attr data-foo=bar}}><a>{{baz}}</a></li>');
+                           '<li data-foo={{bar}}><a>{{baz}}</a></li>');
 });
 
 test("mixture of colon and indentation pt.2", function() {
@@ -72,7 +71,7 @@ test("mixture of colon and indentation pt.2", function() {
              "  li data-foo='bar': a quux",
              "  li data-foo=bar href='#': a quux");
   compilesTo(emblem,
-    '<ul><li {{bind-attr data-foo=bar}}><a>quux</a></li><li data-foo="bar"><a>quux</a></li><li {{bind-attr data-foo=bar}} href="#"><a>quux</a></li></ul>');
+    '<ul><li data-foo={{bar}}><a>quux</a></li><li data-foo="bar"><a>quux</a></li><li data-foo={{bar}} href="#"><a>quux</a></li></ul>');
 });
 
 test("condensed nesting", function(){

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -307,7 +307,7 @@ test('use of "this"', function(){
 
 test('mustache attr with underscore', function(){
   var emblem = 'input placeholder=cat_name';
-  compilesTo(emblem,'<input {{bind-attr placeholder=cat_name}}>');
+  compilesTo(emblem,'<input placeholder={{cat_name}}>');
 });
 
 test('mustache with empty attr value (single-quoted string)', function(){

--- a/tests/unit/template-compiler-test.js
+++ b/tests/unit/template-compiler-test.js
@@ -176,7 +176,7 @@ QUnit.test("compiles complex classNameBindings to a bind-attr", function(assert)
 
   var result = compile(ast);
 
-  assert.equal(result, '<div {{bind-attr class=":size color isHeavy:oof:whee"}}></div>');
+  assert.equal(result, '<div class="size {{color}} {{if isHeavy \'oof\' \'whee\'}}"></div>');
 });
 
 QUnit.test("compiles simple classNameBindings to a class attribute", function(assert){


### PR DESCRIPTION

This is a WIP on enabling the HTMLBars attribute syntax.

This makes a few changes to Emblem's DSL to facilitate this:

## Existing colon syntax maps to inline if
```
div class=foo:bar:baz
```

converts to
 
```
<div class={{ if foo 'bar' 'baz' }}>
```

This syntax seemed important to retain to ensure backwards compatibility (not to mention significant refactoring).  This wraps all of the values as strings as I believe this is how the bindAttr syntax worked.

This will work with mixing unbound and bound class names, as well as single mustache surrounding multiple colon expressions:

```
.alert class={ foo:bar:baz one:two:three }
```

converts to:

```
<div class="alert {{ if foo 'bar' 'baz'}} {{if one 'two' 'three'}}">
```

However, one important thing to note here is the HTMLBars syntax does not convert a true to the variable name, i.e.:
`{{ bind-attr class=foo }}`.

For bindAttr, if `foo===true` then this generates `<div class="foo">`.  However, for HTMLBars this would return `<div class="true">`.  In these cases, users will need to alter the colon syntax slightly to retain the original functionality: `class=foo:foo`.


## Inline if syntax for attributes is support by single mustache
```
class={ if foo bar 'baz' }
```

This allows for more proper HTMLBars syntax for attributes.  This also allows for attribute assignment for both bound and unbound values.  This syntax supports any possible string, so the following should work:

```
class={ if isGoogle 'http://www.google.com' }
```

There are several hacks to this so that existing single mustache expressions should still work.  With this change, any attribute assignment with single mustache passes all of the contents of the mustache unchanged.

One current limitation which I think makes sense is to ignore this rule when inside a quote.  In this case the user should return double mustache:
```
div style="margin-top: {{ model.xValue }}px;"
```

I've done a fair amount of initial testing and so far everything is looking good.  This is my first attempt at PEGjs so I imagine the code could look a lot prettier.  I've tested this against our largish Ember app and so far there are no significant issues.  Other than the one issue with bindAttr -> HTMLBars syntax, this required no refactoring of the code.

<br />

Thoughts?  Are these the best syntax changes?  One thing that seemed a bit hackish was I did a bit of refactoring of how bound and unbound class attributes are parsed, yet it still depends on PEGjs prefixing unbound attributes with a `:`.