### PR TITLE
Added else-if block support

### DIFF
--- a/lib/ast-builder.js
+++ b/lib/ast-builder.js
@@ -66,7 +66,7 @@ var builder = {
       type: 'block',
       content: content,
       childNodes: [],
-      inverseChildNodes: []
+      invertibleNodes: []
     };
   },
 

--- a/lib/mustache-attr-value.pegjs
+++ b/lib/mustache-attr-value.pegjs
@@ -1,0 +1,35 @@
+
+start = newMustacheAttrValue
+
+newMustacheAttrValue = !(m_invalidValueStartChar / m_blockStart) v:(m_quotedString / m_valuePath / m_parenthetical) m_* {
+  return v;
+}
+
+// Copies from mustache-parser
+m_blockStart = "as" m_* "|"
+
+m_invalidValueStartChar = '/' / '['
+
+m_quotedString = $( '"' m_stringWithoutDouble '"' ) / $("'" m_stringWithoutSingle "'")
+
+m_valuePath = $newMustacheNameChar+
+
+m_parenthetical
+= m_* p:$(m_OPEN_PAREN m_inParensChar* m_parenthetical? m_inParensChar* m_CLOSE_PAREN) m_* {
+  return p;
+}
+
+m_inParensChar = [^\(\)]
+
+m_stringWithoutDouble = $(m_inStringChar / "'")*
+m_stringWithoutSingle = $(m_inStringChar / '"')*
+
+m_inStringChar = [^'"]
+
+m_OPEN_PAREN = '('
+m_CLOSE_PAREN = ')'
+
+m_ = ' '
+
+// a character that can be in a mustache name
+newMustacheNameChar = [A-Za-z0-9] / [_/] / '-' / '.'

--- a/lib/mustache-attrs.pegjs
+++ b/lib/mustache-attrs.pegjs
@@ -1,0 +1,43 @@
+
+@import "./mustache-attr-value.pegjs" as newMustacheAttrValue
+
+start = mustacheAttrs
+
+mustacheAttrs = m_bracketedAttrs / newMustacheAttr*
+
+// open bracket followed by mustache attrs on separate lines followed by close bracket.
+// We use the '&' syntax to avoid capturing the close bracket because the upstream parser
+// rules will use it determine if there is nested mustache content following the bracket
+m_bracketedAttrs = m_openBracket attrs:(m_* attr:newMustacheAttr m_TERM? { return attr;})* &m_closeBracket {
+  return attrs;
+}
+
+newMustacheAttr = m_keyValue / m_parenthetical / newMustacheAttrValue
+
+m_keyValue = attrName:newMustacheAttrName m_* '=' m_* attrValue:newMustacheAttrValue m_* {
+  return attrName + '=' + attrValue;
+}
+
+newMustacheAttrName = $newMustacheNameChar+
+
+m_parenthetical
+= m_* p:$(m_OPEN_PAREN m_inParensChar* m_parenthetical? m_inParensChar* m_CLOSE_PAREN) m_* {
+  return p;
+}
+
+m_inParensChar = [^\(\)]
+
+m_OPEN_PAREN = '('
+m_CLOSE_PAREN = ')'
+m_ = ' '
+
+// TERM and INDENT are added by the preprocessor
+m_openBracket = '[' m_TERM m_INDENT
+m_closeBracket = m_* ']'
+
+// copied from (and namespaced with 'm_') the general parser
+m_INDENT "INDENT" = t:. &{ return INDENT_SYMBOL === t; } { return ''; }
+m_TERM  "LineEnd" = "\r"? t:. &{ return TERM_SYMBOL == t; } "\n" { return false; }
+
+// a character that can be in a mustache name
+newMustacheNameChar = [A-Za-z0-9] / [_/] / '-' / '.'

--- a/lib/mustache-parser.pegjs
+++ b/lib/mustache-parser.pegjs
@@ -1,3 +1,7 @@
+
+@import "./mustache-attrs.pegjs" as mustacheAttrs
+@import "./mustache-attr-value.pegjs" as newMustacheAttrValue
+
 start = newMustache
 
 // Returns an object with this shape:
@@ -8,7 +12,7 @@ start = newMustache
 //   modifier: '?' or '!' (optional),
 // }
 // upstream parsers will optionally add an `isEscaped:true` property
-newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAttr*) blockParams:m_blockParams? {
+newMustache = name:newMustacheStart m_* attrs:mustacheAttrs blockParams:m_blockParams? {
   attrs = attrs.concat(name.shorthands);
   var ret = {
     name: name.name,
@@ -22,29 +26,6 @@ newMustache = name:newMustacheStart m_* attrs:(m_bracketedAttrs / newMustacheAtt
   return ret;
 }
 
-m_blockParams = m_blockStart m_* params:blockParamName+ "|" {
-  return params;
-}
-
-m_blockStart = "as" m_* "|"
-
-blockParamName = newMustacheAttrValue
-
-// open bracket followed by mustache attrs on separate lines followed by close bracket.
-// We use the '&' syntax to avoid capturing the close bracket because the upstream parser
-// rules will use it determine if there is nested mustache content following the bracket
-m_bracketedAttrs = m_openBracket attrs:(m_* attr:newMustacheAttr m_TERM? { return attr;})* &m_closeBracket {
-  return attrs;
-}
-
-// TERM and INDENT are added by the preprocessor
-m_openBracket = '[' m_TERM m_INDENT
-m_closeBracket = m_* ']'
-
-// copied from (and namespaced with 'm_') the general parser
-m_INDENT "INDENT" = t:. &{ return INDENT_SYMBOL === t; } { return ''; }
-m_TERM  "LineEnd" = "\r"? t:. &{ return TERM_SYMBOL == t; } "\n" { return false; }
-
 newMustacheStart = name:newMustacheName m_* shorthands:newMustacheShortHand* {
   return {
     name: name.name,
@@ -52,6 +33,14 @@ newMustacheStart = name:newMustacheName m_* shorthands:newMustacheShortHand* {
     shorthands: shorthands
   };
 }
+
+m_blockParams = m_blockStart m_* params:blockParamName+ "|" {
+  return params;
+}
+
+m_blockStart = "as" m_* "|"
+
+blockParamName = newMustacheAttrValue
 
 // shorthand %tagName, .className, #idName
 newMustacheShortHand = m_shortHandTagName / m_shortHandIdName / m_shortHandClassName
@@ -78,42 +67,10 @@ newMustacheName = !m_invalidNameStartChar name:$newMustacheNameChar+ modifier:m_
 }
 
 m_invalidNameStartChar = '.' / '-' / [0-9]
-m_invalidValueStartChar = '/' / '['
 
 // unbound (!) and conditional (?) modifiers
 m_modifierChar = '!' / '?'
 
-// a character that can be in a mustache name
 newMustacheNameChar = [A-Za-z0-9] / [_/] / '-' / '.'
 
-newMustacheAttr = m_keyValue / m_parenthetical / newMustacheAttrValue
-
-m_keyValue = attrName:newMustacheAttrName m_* '=' m_* attrValue:newMustacheAttrValue m_* {
-  return attrName + '=' + attrValue;
-}
-
-newMustacheAttrName = $newMustacheNameChar+
-
-newMustacheAttrValue = !(m_invalidValueStartChar / m_blockStart) v:(m_quotedString / m_valuePath / m_parenthetical) m_* {
-  return v;
-}
-
-m_valuePath = $newMustacheNameChar+
-
-m_quotedString = $( '"' m_stringWithoutDouble '"' ) / $("'" m_stringWithoutSingle "'")
-
-m_stringWithoutDouble = $(m_inStringChar / "'")*
-m_stringWithoutSingle = $(m_inStringChar / '"')*
-
-m_inStringChar = [^'"]
-m_inParensChar = [^\(\)]
-m_commentChar = '/'
-
-m_parenthetical
-= m_* p:$(m_OPEN_PAREN m_inParensChar* m_parenthetical? m_inParensChar* m_CLOSE_PAREN) m_* {
-  return p;
-}
-
-m_OPEN_PAREN = '('
-m_CLOSE_PAREN = ')'
 m_ = ' '

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -1,4 +1,5 @@
 @import "./mustache-parser.pegjs" as newMustache
+@import "./mustache-attrs.pegjs" as mustacheAttrs
 
 {
   var builder = options.builder;
@@ -159,8 +160,9 @@
       var block = builder.generateBlock(mustacheContent, escaped);
       builder.enter(block);
       builder.add('childNodes', blockTuple[0]);
+
       if (blockTuple[1]) {
-        builder.add('inverseChildNodes', blockTuple[1]);
+        builder.add('invertibleNodes', blockTuple[1]);
       }
       return builder.exit();
     } else {
@@ -244,18 +246,10 @@
 
 start = program
 
-program = c:content i:( DEDENT else _ TERM blankLine* indentation c:content {return c;})?
+program = c:content
 {
   builder.add('childNodes', c);
 }
-
-invertibleContent = c:content i:( DEDENT else _ TERM blankLine* indentation c:content {return c;})?
-{
-  return [c,i];
-}
-
-else
-  = ('=' _)? 'else'
 
 content = statements:statement*
 {
@@ -297,7 +291,6 @@ mustache
   return [mustacheOrBlock];
 }
 
-
 commentContent
  = lineContent TERM ( indentation (commentContent)+ anyDedent)* { return []; }
 
@@ -311,6 +304,15 @@ lineStartingMustache
   = mustacheTuple:(capitalizedLineStarterMustache / mustacheOrBlock)
 {
   return mustacheTuple;
+}
+
+explicitMustache = e:equalSign mustacheTuple:mustacheOrBlock
+{
+  var mustache = mustacheTuple[0];
+  var block = mustacheTuple[1];
+  mustache.isEscaped = e;
+
+  return [mustache, block];
 }
 
 capitalizedLineStarterMustache
@@ -397,16 +399,31 @@ mustacheNestedContent
     return block;
   }
 
-
-explicitMustache = e:equalSign mustacheTuple:mustacheOrBlock
+invertibleContent
+  = c:content i:invertibleObject?
 {
-  var mustache = mustacheTuple[0];
-  var block = mustacheTuple[1];
-
-  mustache.isEscaped = e;
-
-  return [mustache, block];
+  return [c, i];
 }
+
+// Return an invertible node object
+// This runs recursively
+invertibleObject
+  = DEDENT b:else _ a:invertibleParam? TERM c:invertibleBlock i:invertibleObject?
+{
+  return { content: c, name: [b, a].join(' '), invertibleNodes: i };
+}
+
+// Captures else / else if statements
+else
+  = ('=' _)? e:('else' _ 'if'?) { return e.join(''); }
+
+// Params for an invertible node
+invertibleParam
+  = p:mustacheAttrs _ inlineComment? { return p; }
+
+// Block for an invertible node
+invertibleBlock
+  = blankLine* indentation c:content { return c; }
 
 inMustache
   = isPartial:'>'? !('[' TERM) _ mustache:newMustache inlineComment? {
@@ -414,6 +431,7 @@ inMustache
     var n = new AST.PartialNameNode(new AST.StringNode(sexpr.id.string));
     return new AST.PartialNode(n, sexpr.params[0], undefined, {});
   }
+
   return mustache;
 }
 

--- a/lib/template-visitor.js
+++ b/lib/template-visitor.js
@@ -1,14 +1,44 @@
+/**
+  Visit a single node
+  @oaram {Object} node
+  @param {Array} opcodes
+*/
 export function visit(node, opcodes) {
   visitor[node.type](node, opcodes);
 }
 
+/**
+  Visit a series of nodes
+  @oaram {Array} nodes
+  @param {Array} opcodes
+*/
 function visitArray(nodes, opcodes) {
   if (!nodes || nodes.length === 0) {
     return;
   }
   for (var i=0, l=nodes.length; i<l; i++) {
-    visit(nodes[i], opcodes);
+    // Due to the structure of invertible nodes, it is possible to receive an array of arrays
+    if (nodes[i] instanceof Array)
+      visitArray(nodes[i], opcodes);
+    else
+      visit(nodes[i], opcodes);
   }
+}
+
+/**
+  Process an invertible object
+  @param {Object} node
+  @param {Array} opcodes
+*/
+function addInvertible(node, opcodes) {
+  opcodes.push(['mustache', [node.name.trim(), true]]);
+
+  // The content helper always returns an array
+  visitArray(node.content, opcodes);
+
+  // Recursion if this node has more invertible nodes
+  if (node.invertibleNodes)
+    addInvertible(node.invertibleNodes, opcodes);
 }
 
 var visitor = {
@@ -55,9 +85,9 @@ var visitor = {
     opcodes.push(['startBlock', [node.content]]);
     visitArray(node.childNodes, opcodes);
 
-    if (node.inverseChildNodes && node.inverseChildNodes.length > 0) {
-      opcodes.push(['mustache', ['else', true]]);
-      visitArray(node.inverseChildNodes, opcodes);
+    // The root block node will have an array of invertibleNodes, but there can only ever be one
+    if (node.invertibleNodes && node.invertibleNodes.length > 0) {
+      addInvertible(node.invertibleNodes[0], opcodes);
     }
 
     opcodes.push(['endBlock', [node.content]]);
@@ -65,6 +95,9 @@ var visitor = {
 
   mustache: function(node, opcodes){
     opcodes.push(['mustache', [node.content, node.escaped]]);
-  }
+  },
 
+  assignedMustache: function(node, opcodes) {
+    opcodes.push(['assignedMustache', [node.content, node.key]]);
+  }
 };

--- a/tests/integration/conditionals-test.js
+++ b/tests/integration/conditionals-test.js
@@ -15,6 +15,16 @@ test("simple if statement", function(){
   compilesTo(emblem, "{{#if foo}}Foo{{/if}}{{#if bar}}Bar{{/if}}");
 });
 
+test("simple if else statement", function(){
+  var emblem = w(
+    "if foo",
+    "  | Foo",
+    "else",
+    "  | Bar"
+  );
+  compilesTo(emblem, "{{#if foo}}Foo{{else}}Bar{{/if}}");
+});
+
 test("if else ", function(){
   var emblem = w(
     "if foo",
@@ -84,3 +94,113 @@ test("else followed by newline doesn't gobble else content", function(){
   compilesTo(emblem, "{{#if something}}<p>something</p>{{else}}{{#if nothing}}<p>nothing</p>{{else}}<p>not nothing</p>{{/if}}{{/if}}");
 });
 
+test("else if block", function(){
+  var emblem = w(
+  "if something",
+  "  p something",
+  "else if somethingElse",
+  "  p nothing"
+  );
+  compilesTo(emblem, "{{#if something}}<p>something</p>{{else if somethingElse}}<p>nothing</p>{{/if}}");
+});
+
+test("else if with else block", function(){
+  var emblem = w(
+  "if something",
+  "  p something",
+  "else if somethingElse",
+  "  p otherThing",
+  "else",
+  "  p nothing"
+  );
+  compilesTo(emblem, "{{#if something}}<p>something</p>{{else if somethingElse}}<p>otherThing</p>{{else}}<p>nothing</p>{{/if}}");
+});
+
+test("else if twice with else block", function(){
+  var emblem = w(
+  "if something",
+  "  p something",
+  "else if somethingElse",
+  "  p otherThing",
+  "else if anotherSomethingElse",
+  "  p otherThing2",
+  "else",
+  "  p nothing"
+  );
+  compilesTo(emblem, "{{#if something}}<p>something</p>{{else if somethingElse}}<p>otherThing</p>{{else if anotherSomethingElse}}<p>otherThing2</p>{{else}}<p>nothing</p>{{/if}}");
+});
+
+test("else if with extra nodes", function(){
+  var emblem = w(
+  "if something",
+  "  p something",
+  "  h2",
+  "    p something",
+  "else if somethingElse",
+  "  p otherThing",
+  "  if twoThree",
+  "    strong 2:3",
+  "  else if twoFour",
+  "    strong 2:4",
+  "else if anotherSomethingElse",
+  "  p otherThing2",
+  "  h2",
+  "    h4",
+  "      p something",
+  "else",
+  "  p nothing"
+  );
+  compilesTo(emblem, "{{#if something}}<p>something</p><h2><p>something</p></h2>" +
+                     "{{else if somethingElse}}<p>otherThing</p>{{#if twoThree}}<strong>2:3</strong>{{else if twoFour}}<strong>2:4</strong>{{/if}}" +
+                     "{{else if anotherSomethingElse}}<p>otherThing2</p><h2><h4><p>something</p></h4></h2>" +
+                     "{{else}}<p>nothing</p>{{/if}}");
+});
+
+test("else if with component block", function() {
+  var emblem = w(
+    "if something",
+    "  = my-component/widget-a value=model.options as |component indexWidget|",
+    "    p The current value is #{ indexWidget }",
+    "    strong = component.warningMessage",
+    "else if somethingElse",
+    "  h5 Danger!"
+  );
+  compilesTo(emblem, '{{#if something}}{{#my-component/widget-a value=model.options as |component indexWidget|}}<p>The current value is {{indexWidget }}</p><strong>{{component.warningMessage}}</strong>{{/my-component/widget-a}}' +
+                     '{{else if somethingElse}}<h5>Danger!</h5>{{/if}}');
+});
+
+test("inline if with unbound statements", function() {
+  var emblem = w(
+    "if something 'something' 'somethingElse'"
+  );
+  compilesTo(emblem, "{{if something 'something' 'somethingElse'}}");
+});
+
+test("inline if with bound statements", function() {
+  var emblem = w(
+    "if something something 'somethingElse'"
+  );
+  compilesTo(emblem, "{{if something something 'somethingElse'}}");
+});
+
+test("truth helpers syntax test 1", function() {
+  var emblem = w(
+    "if (eq 1 2)",
+    "  |1 == 2",
+    "unless (eq 1 2)",
+    "  |1 != 2"
+  );
+  compilesTo(emblem, "{{#if (eq 1 2)}}1 == 2{{/if}}{{#unless (eq 1 2)}}1 != 2{{/unless}}");
+});
+
+test("truth helpers syntax test 2", function() {
+  var emblem = w(
+    "if (is-array siblings)",
+    "  each siblings as |sibling|",
+    "    |My sibling: #{ sibling }",
+    "else if (and (not model.isLoading) model.isError)",
+    "  p Hey!"
+  );
+  compilesTo(emblem, "{{#if (is-array siblings)}}{{#each siblings as |sibling|}}My sibling: {{sibling }}{{/each}}" +
+                     "{{else if (and (not model.isLoading) model.isError)}}<p>Hey!</p>{{/if}}");
+});

--- a/tests/unit/template-compiler-test.js
+++ b/tests/unit/template-compiler-test.js
@@ -119,10 +119,17 @@ QUnit.test("compiles block with inverse AST", function(assert){
             content: 'hello there'
           }
         ],
-        inverseChildNodes: [
+        invertibleNodes: [
           {
-            type: 'text',
-            content: 'not hello there'
+            content: [
+              [
+                {
+                  type: 'text',
+                  content: 'not hello there'
+                }
+              ]
+            ],
+            name: 'else'
           }
         ]
       }


### PR DESCRIPTION
This adds basic `else if` support.

I had to extract the logic for mustache attrs from `mustache-parser.pegjs` so that the `else` blocks could reuse it.  I'm not as happy with how that ended up since some rules had to be duplicated across the 3 `mustache-` pegjs files.

This also required some changes to the api for invertible nodes so that they could be nested.