### PR TITLE
Allow bracketed params as a part of a mustache value

### DIFF
--- a/lib/mustache-attr-value.pegjs
+++ b/lib/mustache-attr-value.pegjs
@@ -1,4 +1,6 @@
 
+@import "./mustache-name-character.pegjs" as newMustacheNameChar
+
 start = newMustacheAttrValue
 
 newMustacheAttrValue = !(m_invalidValueStartChar / m_blockStart) v:(m_quotedString / m_valuePath / m_parenthetical) m_* {
@@ -8,7 +10,7 @@ newMustacheAttrValue = !(m_invalidValueStartChar / m_blockStart) v:(m_quotedStri
 // Copies from mustache-parser
 m_blockStart = "as" m_* "|"
 
-m_invalidValueStartChar = '/' / '['
+m_invalidValueStartChar = '/'
 
 m_quotedString = $( '"' m_stringWithoutDouble '"' ) / $("'" m_stringWithoutSingle "'")
 
@@ -30,6 +32,3 @@ m_OPEN_PAREN = '('
 m_CLOSE_PAREN = ')'
 
 m_ = ' '
-
-// a character that can be in a mustache name
-newMustacheNameChar = [A-Za-z0-9] / [_/] / '-' / '.'

--- a/lib/mustache-name-character.pegjs
+++ b/lib/mustache-name-character.pegjs
@@ -1,0 +1,8 @@
+
+start = newMustacheNameChar
+
+// a character that can be in a mustache name
+newMustacheNameChar = [A-Za-z0-9] / [_/] / '-' / m_arrayIndex / '.'
+
+// Ember requires that array indexes have a . before them
+m_arrayIndex = '.' '[' newMustacheNameChar* ']'

--- a/lib/mustache-parser.pegjs
+++ b/lib/mustache-parser.pegjs
@@ -1,6 +1,7 @@
 
 @import "./mustache-attrs.pegjs" as mustacheAttrs
 @import "./mustache-attr-value.pegjs" as newMustacheAttrValue
+@import "./mustache-name-character.pegjs" as newMustacheNameChar
 
 start = newMustache
 
@@ -70,7 +71,5 @@ m_invalidNameStartChar = '.' / '-' / [0-9]
 
 // unbound (!) and conditional (?) modifiers
 m_modifierChar = '!' / '?'
-
-newMustacheNameChar = [A-Za-z0-9] / [_/] / '-' / '.'
 
 m_ = ' '

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -397,3 +397,25 @@ test("several brackets with closing bracket on final line with a view", function
   );
   return compilesTo(emblem, '{{view Ember.Select thing=res1 thi2ng=\'res2\' otherThing="res3"}}');
 });
+
+test("single-line mustaches can have array indexes", function(){
+  var emblem = w('my-component value=child.[0]');
+  compilesTo(emblem,
+    '{{my-component value=child.[0]}}');
+});
+
+test("single-line mustaches can have array indexes with bound indexes (not supported by Ember)", function(){
+  var emblem = w('my-component value=child.[someIndex]');
+  compilesTo(emblem,
+    '{{my-component value=child.[someIndex]}}');
+});
+
+test("multi-line mustaches can have array indexes with blocks", function(){
+  var emblem = w(
+    'my-component [',
+    '  value=child.[0] ]',
+    '  | Thing'
+  );
+  compilesTo(emblem,
+    '{{#my-component value=child.[0]}}Thing{{/my-component}}');
+});


### PR DESCRIPTION
This allows for mustache attribute values to have array indexes (though this doesn't seem to be supported very well by Ember).

Should fix [#231](https://github.com/machty/emblem.js/issues/231).