### PR TITLE
Multiple child nodes in one block confused as an invertible node

### DIFF
--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -159,11 +159,18 @@
     if (blockTuple && blockTuple.length > 0) {
       var block = builder.generateBlock(mustacheContent, escaped);
       builder.enter(block);
-      builder.add('childNodes', blockTuple[0]);
 
-      if (blockTuple[1]) {
-        builder.add('invertibleNodes', blockTuple[1]);
-      }
+      // Iterate on each tuple and either add it as a child node or an invertible node
+      blockTuple.forEach(function(tuple) {
+        if (!tuple)
+          return;
+
+        if (tuple.isInvertible)
+          builder.add('invertibleNodes', tuple);
+        else
+          builder.add('childNodes', tuple);
+      });
+
       return builder.exit();
     } else {
       return builder.generateMustache(mustacheContent, escaped);
@@ -399,17 +406,26 @@ mustacheOrBlock = mustacheContent:inMustache _ inlineComment? blockTuple:mustach
 colonContent = ': ' _ c:contentStatement { return c; }
 
 mustacheNestedContent
-  = statements:(colonContent / textLine) { return statements; }
+  // Inline content that should be nested (colon or single pipe)
+  = statements:(colonContent / textLine) {
+    return statements;
+  }
+  // Inline content or an HTML element after a closing argument bracket
   / _ ']' TERM statements:(colonContent / textLine / htmlElement) DEDENT {
     return statements;
   }
+  // Indented invertible block
   / TERM block:(blankLine* indentation i:invertibleContent DEDENT { return i })? {
     return block;
   }
+  // Block with invertible content after a closing argument bracket
   / _ ']' TERM block:invertibleContent DEDENT {
     return block;
   }
-  / _ DEDENT? ']' TERM { return; }
+  // Closing argument bracket
+  / _ DEDENT? ']' TERM {
+    return;
+  }
 
 invertibleContent
   = c:content i:invertibleObject?
@@ -422,7 +438,7 @@ invertibleContent
 invertibleObject
   = DEDENT b:else _ a:invertibleParam? TERM c:invertibleBlock i:invertibleObject?
 {
-  return { content: c, name: [b, a].join(' '), invertibleNodes: i };
+  return { content: c, name: [b, a].join(' '), isInvertible: true, invertibleNodes: i };
 }
 
 // Captures else / else if statements

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -198,6 +198,12 @@ test("# can be only thing on line", function(){
     "<span>#</span>");
 });
 
+test("brace works with text pipe", function() {
+  var emblem = `= link-to 'users.view' user | View user #{ user.name } #{ user.id }`;
+  compilesTo(emblem, '{{#link-to \'users.view\' user}}View user {{user.name }} {{user.id }}{{/link-to}}');
+});
+
+
 QUnit.module("mustache: inline block helper");
 
 test("text only", function() {


### PR DESCRIPTION
This should fix [#241](https://github.com/machty/emblem.js/issues/241)