### PR TITLE
Syntax addition for plaintext

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -12,4 +12,3 @@ export function compile(emblem) {
   var result = compileTemplate(ast);
   return result;
 }
-

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -9,7 +9,9 @@
 
   var LINE_SPACE_MODIFIERS = {
     NEWLINE: '`',
-    SPACE: "'"
+    SPACE_AFTER: "'",
+    SPACE_BOTH: '"',
+    SPACE_BEFORE: "+"
   };
 
   var KNOWN_TAGS = {
@@ -540,7 +542,7 @@ whitespaceableTextNodes
  / textNodes
 
 textLineStart
- = s:[|`'] ' '?  { return s; }
+ = s:[|`'+"] ' '?  { return s; }
  / &'<' { return '<'; }
 
 // indentedNodes is an array of arrays,
@@ -570,14 +572,20 @@ textLine = s:textLineStart nodes:textNodes indentedNodes:(indentation w:whitespa
 
       // connect logical lines with a space, skipping the next-to-last line
       if (i < l - 1) { nodes.push(' '); }
+
     }
   }
 
   // add trailing space to non-indented nodes if special modifier
-  if (s === LINE_SPACE_MODIFIERS.SPACE) {
+  if (s === LINE_SPACE_MODIFIERS.SPACE_AFTER) {
     nodes.push(' ');
   } else if (s === LINE_SPACE_MODIFIERS.NEWLINE) {
     nodes.push('\n');
+  } else if (s === LINE_SPACE_MODIFIERS.SPACE_BOTH) {
+    nodes.push(' ');
+    nodes.unshift(' ');
+  } else if (s === LINE_SPACE_MODIFIERS.SPACE_BEFORE) {
+    nodes.unshift(' ');
   }
 
   return castStringsToTextNodes(nodes);

--- a/lib/preprocessor.js
+++ b/lib/preprocessor.js
@@ -9,8 +9,7 @@ export var DEDENT_SYMBOL = '\uEFFE';
 export var UNMATCHED_DEDENT_SYMBOL = '\uEFEE';
 export var TERM_SYMBOL = '\uEFFF';
 
-// Prints an easy-to-read version of the preprocessed string for
-// debugging
+// Prints an easy-to-read version of the preprocessed string for debugging
 function prettyPrint(string){
   var indent = new RegExp(INDENT_SYMBOL, 'g');
   var dedent = new RegExp(DEDENT_SYMBOL, 'g');
@@ -90,7 +89,7 @@ function Preprocessor() {
   };
 }
 
-Preprocessor.prototype.p = function(s) {
+Preprocessor.prototype.appendToOutput = function(s) {
   if (s) {
     this.output += s;
   }
@@ -98,7 +97,7 @@ Preprocessor.prototype.p = function(s) {
 };
 
 Preprocessor.prototype.scan = function(r) {
-  return this.p(this.ss.scan(r));
+  return this.appendToOutput(this.ss.scan(r));
 };
 
 Preprocessor.prototype.discard = function(r) {
@@ -118,46 +117,49 @@ processInput = function(isEnd) {
         case INDENT_SYMBOL:
           if (this.ss.bol() || this.discard(any_whitespaceFollowedByNewlines_)) {
             if (this.discard(new RegExp("[" + ws + "]*\\r?\\n"))) {
-              this.p("" + TERM_SYMBOL + "\n");
+              this.appendToOutput("" + TERM_SYMBOL + "\n");
               continue;
             }
             if (this.base != null) {
               if ((this.discard(this.base)) == null) {
                 throw new Error("inconsistent base indentation");
               }
-            } else {
+            }
+            else {
               b = this.discard(new RegExp("[" + ws + "]*"));
               this.base = new RegExp("" + b);
             }
             if (this.indents.length === 0) {
-              if (this.ss.check(new RegExp("[" + ws + "]+"))) {
-                this.p(INDENT_SYMBOL);
+              if (this.ss.check(new RegExp("[" + ws + "]*"))) {
+                this.appendToOutput(INDENT_SYMBOL);
                 this.context.observe(INDENT_SYMBOL);
-                this.indents.push(this.scan(new RegExp("([" + ws + "]+)")));
+                this.indents.push(this.scan(new RegExp("([" + ws + "]*)")));
               }
-            } else {
+            }
+            else {
               indent = this.indents[this.indents.length - 1];
               if (d = this.ss.check(new RegExp("(" + indent + ")"))) {
                 this.discard(d);
                 if (this.ss.check(new RegExp("([" + ws + "]+)"))) {
-                  this.p(INDENT_SYMBOL);
+                  this.appendToOutput(INDENT_SYMBOL);
                   this.context.observe(INDENT_SYMBOL);
                   this.indents.push(d + this.scan(new RegExp("([" + ws + "]+)")));
                 }
-              } else {
+              }
+              else {
                 while (this.indents.length) {
                   indent = this.indents[this.indents.length - 1];
                   if (this.discard(new RegExp("(?:" + indent + ")"))) {
                     break;
                   }
                   this.context.observe(DEDENT_SYMBOL);
-                  this.p(DEDENT_SYMBOL);
+                  this.appendToOutput(DEDENT_SYMBOL);
                   this.indents.pop();
                 }
                 if (s = this.discard(new RegExp("[" + ws + "]+"))) {
                   this.output = this.output.slice(0, -1);
                   this.output += UNMATCHED_DEDENT_SYMBOL;
-                  this.p(INDENT_SYMBOL);
+                  this.appendToOutput(INDENT_SYMBOL);
                   this.context.observe(INDENT_SYMBOL);
                   this.indents.push(s);
                 }
@@ -166,7 +168,7 @@ processInput = function(isEnd) {
           }
           this.scan(/[^\r\n]+/);
           if (this.discard(/\r?\n/)) {
-            this.p("" + TERM_SYMBOL + "\n");
+            this.appendToOutput("" + TERM_SYMBOL + "\n");
           }
       }
     }
@@ -174,7 +176,7 @@ processInput = function(isEnd) {
       this.scan(anyWhitespaceAndNewlinesTouchingEOF);
       while (this.context.length && INDENT_SYMBOL === this.context.peek()) {
         this.context.observe(DEDENT_SYMBOL);
-        this.p(DEDENT_SYMBOL);
+        this.appendToOutput(DEDENT_SYMBOL);
       }
       if (this.context.length) {
         throw new Error('Unclosed ' + (this.context.peek()) + ' at EOF');

--- a/tests/integration/text-line-test.js
+++ b/tests/integration/text-line-test.js
@@ -6,6 +6,10 @@ import { compilesTo } from '../support/integration-assertions';
 
 var runTextLineSuite;
 
+/*
+  Default plaintext format
+ */
+
 QUnit.module("text lines: starting with '|'");
 
 test("basic", function() {
@@ -89,6 +93,10 @@ test("with blank", function() {
   compilesTo(
     emblem, '<pre>This  should hopefully   work, and work well.</pre>');
 });
+
+/*
+  Add a newline after formatting the plaintext
+ */
 
 QUnit.module("text lines: starting with '`' -- backtick ADDS a trailing newline");
 
@@ -184,6 +192,10 @@ test("with blank", function() {
     emblem, '<pre>This\n  should\n\n hopefully\n   work, and work well.\n</pre>');
 });
 
+/*
+  Add an extra space after
+ */
+
 QUnit.module('text lines: starting with "\'" should add an extra space');
 
 test("basic", function() {
@@ -272,5 +284,197 @@ test("with blank", function() {
     '  hopefully
     '    work, and work well.`;
   var expected = '<pre>This   should   hopefully    work, and work well. </pre>';
+  compilesTo(emblem, expected);
+});
+
+/*
+  Add an extra space before
+ */
+
+QUnit.module('text lines: starting with "+" should add an extra space before');
+
+test("basic", function() {
+  compilesTo("+ What what", " What what");
+});
+
+test("with html", function() {
+  compilesTo('+ What <span id="woot" data-t="oof" class="f">what</span>!',
+      ' What <span id="woot" data-t="oof" class="f">what</span>!');
+});
+
+test("multiline", function() {
+  var emblem;
+  emblem = `+ Blork
+  Snork`;
+  compilesTo(emblem, " Blork Snork");
+});
+
+test("triple multiline", function() {
+  var emblem;
+  emblem = `+ Blork
+  Snork
+  Bork`;
+  compilesTo(emblem, " Blork Snork Bork");
+});
+
+test("quadruple multiline", function() {
+  var emblem;
+  emblem = `+ Blork
+  Snork
+  Bork
+  Fork`;
+  compilesTo(emblem, " Blork Snork Bork Fork");
+});
+
+test("multiline w/ trailing whitespace", function() {
+  var emblem;
+  emblem = `+ Blork
+  Snork`;
+  compilesTo(emblem, " Blork Snork");
+});
+
+test("secondline", function() {
+  var emblem;
+  emblem = "+\n  Good";
+  compilesTo(emblem, " Good");
+});
+
+test("secondline multiline", function() {
+  var emblem;
+  emblem = "+ \n  Good\n  Bork";
+  compilesTo(emblem, " Good Bork");
+});
+
+test("with a mustache", function() {
+  var emblem;
+  emblem = "+ Bork {{foo}}!";
+  compilesTo(emblem, ' Bork {{foo}}!');
+});
+
+test("with mustaches", function() {
+  var emblem;
+  emblem = "+ Bork {{foo}} {{{bar}}}!";
+  compilesTo(emblem, ' Bork {{foo}} {{{bar}}}!');
+});
+
+test("on each line", function() {
+  var emblem;
+  emblem = `
+  pre
+    + This
+    +   should
+    +  hopefully
+    +    work, and work well.`;
+  compilesTo(
+      emblem, `<pre> This   should  hopefully    work, and work well.</pre>`);
+});
+
+test("with blank", function() {
+  var emblem;
+  emblem = `
+  pre
+    + This
+    +   should
+    +
+    +  hopefully
+    +    work, and work well.`;
+  var expected = '<pre> This   should   hopefully    work, and work well.</pre>';
+  compilesTo(emblem, expected);
+});
+
+/*
+ Add an extra space before and after
+ */
+
+QUnit.module('text lines: starting with "\"" should add an extra space before and after');
+
+test("basic", function() {
+  var emblem;
+  emblem = `" What what`;
+  compilesTo(emblem, " What what ");
+});
+
+test("with html", function() {
+  compilesTo('" What <span id="woot" data-t="oof" class="f">what</span>!',
+      ' What <span id="woot" data-t="oof" class="f">what</span>! ');
+});
+
+test("multiline", function() {
+  var emblem;
+  emblem = `" Blork
+  Snork`;
+  compilesTo(emblem, " Blork Snork ");
+});
+
+test("triple multiline", function() {
+  var emblem;
+  emblem = `" Blork
+  Snork
+  Bork`;
+  compilesTo(emblem, " Blork Snork Bork ");
+});
+
+test("quadruple multiline", function() {
+  var emblem;
+  emblem = `" Blork
+  Snork
+  Bork
+  Fork`;
+  compilesTo(emblem, " Blork Snork Bork Fork ");
+});
+
+test("multiline w/ trailing whitespace", function() {
+  var emblem;
+  emblem = `" Blork
+  Snork`;
+  compilesTo(emblem, " Blork Snork ");
+});
+
+test("secondline", function() {
+  var emblem;
+  emblem = `"\n  Good`;
+  compilesTo(emblem, " Good ");
+});
+
+test("secondline multiline", function() {
+  var emblem;
+  emblem = `"\n  Good\n  Bork`;
+  compilesTo(emblem, " Good Bork ");
+});
+
+test("with a mustache", function() {
+  var emblem;
+  emblem = `" Bork {{foo}}!`;
+  compilesTo(emblem, ' Bork {{foo}}! ');
+});
+
+test("with mustaches", function() {
+  var emblem;
+  emblem = `" Bork {{foo}} {{{bar}}}!`;
+  compilesTo(emblem, ' Bork {{foo}} {{{bar}}}! ');
+});
+
+test("on each line", function() {
+  var emblem;
+  emblem = `
+  pre
+    " This
+    "   should
+    "  hopefully
+    "    work, and work well.`;
+  compilesTo(
+      emblem, '<pre> This    should   hopefully     work, and work well. </pre>');
+});
+
+test("with blank", function() {
+  var emblem;
+  emblem = `
+  pre
+   " This
+   "   should
+   "
+   "  hopefully
+   "    work, and work well.`;
+  var expected = '<pre> This    should     hopefully     work, and work well. </pre>';
   compilesTo(emblem, expected);
 });


### PR DESCRIPTION
New syntax for plaintext formatting :
- `"` to add both a leading and a trailing whitespace
- `+` to add a leading whitespace

Fixes #156 

Existing tests on the current syntax were adapted and all passed successfully.