### PR TITLE
fix a parser bug with actions

### DIFF
--- a/lib/pegjs/html/alias-action.pegjs
+++ b/lib/pegjs/html/alias-action.pegjs
@@ -53,7 +53,7 @@ actionAttribute
 
   var actionContent = [actionBody];
 
-  if (actionBody.indexOf('action') === -1) {
+  if (actionBody.indexOf('action ') !== 0) {
     actionContent.unshift('action');
   }
 

--- a/tests/integration/actions-test.js
+++ b/tests/integration/actions-test.js
@@ -11,6 +11,16 @@ test("basic (click)", function(){
   compilesTo(emblem, '<button {{action "submitComment" on="click"}}>Submit Comment</button>');
 });
 
+test("basic (click) preceded by action keyword", function(){
+  var emblem = 'button click="action submitComment" Submit Comment';
+  compilesTo(emblem, '<button {{action submitComment on="click"}}>Submit Comment</button>');
+});
+
+test("action has action in its name", function(){
+  var emblem = 'button click="submitTransaction" Submit Comment';
+  compilesTo(emblem, '<button {{action "submitTransaction" on="click"}}>Submit Comment</button>');
+});
+
 test("basic (click) followed by attr", function(){
   var emblem = 'button click="submitComment" class="foo" Submit Comment';
   compilesTo(emblem, '<button {{action "submitComment" on="click"}} class="foo">Submit Comment</button>');


### PR DESCRIPTION
if an action had `action` in its name, the parser would generate an
invalid hbs output