### PR TITLE
Refactoring and fix for bracketed attributes

### DIFF
--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -287,7 +287,14 @@ capitalizedLineStarterMustache
 }
 
 
-mustacheOrBlock = mustacheContent:mustacheContent _ inlineComment? blockTuple:mustacheNestedContent
+mustacheOrBlock = mustacheWithBlock / mustacheWithBracketsAndBlock
+
+/**
+  A mustache statement, can also include `>` partial syntax
+
+  @return [<mustacheAst, blockTuple>]
+*/
+mustacheWithBlock = mustacheContent:mustacheContentWithPartial _ inlineComment? blockTuple:mustacheBasicNested
 {
   if (blockTuple) {
     return [mustacheContent, blockTuple];
@@ -296,8 +303,8 @@ mustacheOrBlock = mustacheContent:mustacheContent _ inlineComment? blockTuple:mu
   }
 }
 
-mustacheContent
-  = isPartial:'>'? !('[' TERM) _ mustache:mustacheAst inlineComment? {
+mustacheContentWithPartial
+  = isPartial:'>'? _ mustache:mustacheAst inlineComment? {
   if(isPartial) {
     var n = new AST.PartialNameNode(new AST.StringNode(sexpr.id.string));
     return new AST.PartialNode(n, sexpr.params[0], undefined, {});
@@ -306,26 +313,87 @@ mustacheContent
   return mustache;
 }
 
-// @return [block tuple]
-mustacheNestedContent
+/**
+  Both inline block form and indented:
+  `= each foo: p Hello`    =>    {{#each foo}}<p>Hello</p>{{/each}}
+
+  ```
+  = each foo
+    p Hello
+  = else
+    p Bar
+  ```
+  @return [block tuple]
+*/
+mustacheBasicNested
   // Inline content that should be nested (colon or single pipe)
   = statements:(colonContent / textLine) {
     return {
       blockTuple: statements
     };
   }
-  // Inline content or an HTML element after a closing argument bracket
-  / _ ']' TERM statements:(colonContent / textLine / content) DEDENT {
-    return {
-      blockTuple: statements
-    };
-  }
+
   // Indented invertible block
   / TERM block:(blankLine* indentation i:invertibleContent DEDENT { return i })? {
     return {
       blockTuple: block
     };
   }
+
+
+/**
+  A mustache statement with bracketed params
+  (does not support partial helper)
+
+  @return [<mustacheAst, blockTuple>]
+*/
+mustacheWithBracketsAndBlock = mustacheContent:mustacheContentWithBracketStart _ inlineComment? blockTuple:mustacheBracketNested
+{
+  if (blockTuple) {
+    return [mustacheContent, blockTuple];
+  } else {
+    return [mustacheContent];
+  }
+}
+
+/**
+  This ignores the bracket open, but tests for the bracket close.
+  `mustache/attr-statement` absorbs the bracket open for us, so that the mustache AST
+  can also correct detect the start of a mustache statement.
+*/
+mustacheContentWithBracketStart = !('[' TERM) _ mustache:mustacheAst inlineComment? {
+  return mustache;
+}
+
+/**
+  Captures bracketed syntax for mustache with option of having nested content
+
+  ```
+  = foo [
+    bar
+    baz = 1 ]
+    p Hi
+  ```
+
+  ```
+  = if [
+    foo
+  ]
+    p Hi
+  = else
+    p Bye
+  ```
+
+  @return [block tuple]
+*/
+mustacheBracketNested
+  // Inline content or an HTML element after a closing argument bracket
+  = _ ']' TERM statements:(colonContent / textLine / content) DEDENT {
+    return {
+      blockTuple: statements
+    };
+  }
+
   // Block with invertible content after a closing argument bracket
   / _ ']' _ blockParams:blockParams? TERM block:invertibleContent DEDENT {
     return {
@@ -367,6 +435,9 @@ invertibleContent
   return [c, i];
 }
 
+/**
+  Captures all of the possible endings to a statement that can indicate it is invertible
+*/
 invertibleObject
   = DEDENT comment* b:else _ a:invertibleParam? TERM c:invertibleBlock i:invertibleObject?
 {

--- a/lib/parser.pegjs
+++ b/lib/parser.pegjs
@@ -216,17 +216,57 @@ htmlElement = h:inHtmlTag nested:htmlTerminator
 // terminator.
 htmlTerminator
   = colonContent
+
   / _ mustacheTuple:explicitMustache {
     var blockOrMustache = createBlockOrMustache(mustacheTuple);
 
     return [blockOrMustache];
   }
+
+  /**
+    Indented content
+
+    div
+      p Foo
+  */
   / _ inlineComment? TERM c:indentedContent? {
     return c;
   }
+
+  /**
+    Indented content after closing bracket
+
+    div [
+      foo=bar
+    ]
+      p Foo
+  */
+  / _ inlineComment? DEDENT ']' TERM c:indentedContent? {
+    return c;
+  }
+
+  /**
+    Closing bracket on final line and block
+
+    div [
+      foo=bar ]
+      p Foo
+  */
   / _ inlineComment? ']' TERM c:unindentedContent? {
     return c;
-  } // bracketed
+  }
+
+  /**
+    Closing bracket (both same line and new line)
+
+    div [
+      foo=bar
+    ]
+    div [
+      foo=bar ]
+  */
+  / _ inlineComment?  DEDENT? ']' TERM
+
   / h:htmlNestedTextNodes {
     return h;
   }
@@ -387,28 +427,61 @@ mustacheContentWithBracketStart = !('[' TERM) _ mustache:mustacheAst inlineComme
   @return [block tuple]
 */
 mustacheBracketNested
-  // Inline content or an HTML element after a closing argument bracket
+  /**
+    Inline content or an HTML element after a closing argument bracket
+
+    = foo [
+      foo=bar ]
+      p Foo
+  */
   = _ ']' TERM statements:(colonContent / textLine / content) DEDENT {
     return {
       blockTuple: statements
     };
   }
 
-  // Block with invertible content after a closing argument bracket
+  /**
+    Block with invertible content after a closing argument bracket
+
+    = foo [
+      foo=bar ] as |foo|
+      p Foo
+    = else
+      = foo
+  */
   / _ ']' _ blockParams:blockParams? TERM block:invertibleContent DEDENT {
     return {
       blockParams: blockParams,
       blockTuple: block
     };
   }
-  // Block with invertible content after a closing argument bracket, but with a de-indented closing bracket
+
+  /**
+    Block with invertible content after a closing argument bracket, but with a de-indented closing bracket
+
+    = foo [
+      foo=bar
+    ] as |foo|
+      p Foo
+    = else
+      = foo
+  */
   / _ DEDENT ']' _ blockParams:blockParams? TERM INDENT _ block:invertibleContent DEDENT {
     return {
       blockParams: blockParams,
       blockTuple: block
     };
   }
-  // Closing argument bracket (both same line and new line)
+
+  /**
+    Closing argument bracket (both same line and new line)
+
+    = foo [
+      foo=bar
+    ]
+    = foo [
+      foo=bar ]
+  */
   / _ DEDENT? ']' TERM {
     return;
   }

--- a/lib/pegjs/comment.pegjs
+++ b/lib/pegjs/comment.pegjs
@@ -1,12 +1,16 @@
 @import "./any-dedent.pegjs" as anyDedent
 @import "./indentation.pegjs" as indentation
 @import "./line-content.pegjs" as lineContent
+@import "./whitespace.pegjs" as _
 
 start = comment
 
 comment
   = '/' commentContent { return []; }
 
+/**
+  Absorb everything indented under the comment
+*/
 commentContent
  = lineContent TERM ( indentation (commentContent)+ anyDedent)* { return []; }
 

--- a/lib/pegjs/html/tag-component.pegjs
+++ b/lib/pegjs/html/tag-component.pegjs
@@ -1,3 +1,5 @@
+// @NOTE This file is very similar to tag-html.  It may be possible to merge them at some point.
+
 @import "./attribute.pegjs" as attribute
 @import "./attribute-bracketed.pegjs" as bracketedAttribute
 @import "./attribute-shorthand.pegjs" as shorthandAttributes

--- a/lib/pegjs/html/tag-html.pegjs
+++ b/lib/pegjs/html/tag-html.pegjs
@@ -1,3 +1,5 @@
+// @NOTE This file is very similar to tag-component.  It may be possible to merge them at some point.
+
 @import "./attribute.pegjs" as attribute
 @import "./attribute-bracketed.pegjs" as bracketedAttribute
 @import "./attribute-shorthand.pegjs" as shorthandAttributes
@@ -5,6 +7,7 @@
 @import "../mustache/ast/in-tag.pegjs" as inTagMustache
 @import "../whitespace.pegjs" as _
 @import "../whitespace-req.pegjs" as __
+@import "../inline-comment.pegjs" as inlineComment
 
 start = tagHtml
 
@@ -15,9 +18,11 @@ start = tagHtml
   p#some-id class="asdasd"
   #some-id data-foo="sdsdf"
   p{ action "click" target="view" }
+
+  This also needs to absorb comments for when using brackets
 */
 tagHtml
-= h:htmlStart __ '[' TERM* inTagMustaches:inTagMustache* fullAttributes:bracketedAttribute+
+= h:htmlStart __ '[' TERM* inTagMustaches:inTagMustache* fullAttributes:bracketedAttribute+ (_ inlineComment _ TERM)*
 {
   return parseInHtml(h, inTagMustaches, fullAttributes);
 }

--- a/lib/pegjs/mustache/attr-statement.pegjs
+++ b/lib/pegjs/mustache/attr-statement.pegjs
@@ -2,6 +2,7 @@
 @import "./attr-value.pegjs" as mustacheAttrValue
 @import "../key.pegjs" as key
 @import "../comment.pegjs" as comment
+@import "../blank-line.pegjs" as blankLine
 
 start = mustacheAttrs
 
@@ -13,7 +14,7 @@ mustacheAttrs = bracketedAttrs / mustacheAttr*
   - open bracket followed by mustache attrs on separate lines followed by close bracket.
   - We use the '&' syntax to avoid capturing the close bracket because the upstream parser rules will use it determine if there is nested mustache content following the bracket.
 */
-bracketedAttrs = openBracket attrs:(bracketedAttr / comment)* &closeBracket {
+bracketedAttrs = openBracket attrs:(bracketedAttr / comment / blankLine)* &closeBracket {
   // Filter out comments
   // @NOTE This will not handle a comment as the first item because of the way the comment parser is structured
   return attrs.filter(function(attr) {

--- a/lib/pegjs/mustache/attr-statement.pegjs
+++ b/lib/pegjs/mustache/attr-statement.pegjs
@@ -13,8 +13,17 @@ mustacheAttrs = bracketedAttrs / mustacheAttr*
 
   - open bracket followed by mustache attrs on separate lines followed by close bracket.
   - We use the '&' syntax to avoid capturing the close bracket because the upstream parser rules will use it determine if there is nested mustache content following the bracket.
+  - this will also absorb a single initial value, e.g.:
+  ```
+  = component foo [
+    bar=baz
+  ]
+  ```
 */
-bracketedAttrs = openBracket attrs:(bracketedAttr / comment / blankLine)* &closeBracket {
+bracketedAttrs = initialAttr:mustacheAttrValue? openBracket attrs:(bracketedAttr / comment / blankLine)* &closeBracket {
+  if (initialAttr)
+    attrs.unshift(initialAttr);
+
   // Filter out comments
   // @NOTE This will not handle a comment as the first item because of the way the comment parser is structured
   return attrs.filter(function(attr) {

--- a/tests/integration/attributes-test.js
+++ b/tests/integration/attributes-test.js
@@ -388,6 +388,15 @@ test("in brackets", function() {
   return compilesTo(emblem, '<p id={{id}} some-data={{data.ok}}></p>');
 });
 
+test('brackets with empty lines', function() {
+  var emblem = w('p [',
+                 '  id=id',
+                 '  ',
+                 '',
+                 '  some-data=data.ok]');
+  compilesTo(emblem, '<p id={{id}} some-data={{data.ok}}></p>');
+});
+
 test("class special syntax with 2 vals", function() {
   var emblem = 'p class=foo:bar:baz';
   compilesTo(emblem, '<p class={{if foo \'bar\' \'baz\'}}></p>');

--- a/tests/integration/attributes-test.js
+++ b/tests/integration/attributes-test.js
@@ -65,6 +65,26 @@ test("bracketed text indented", function() {
   return compilesTo(emblem, '<p>[ Bracketed text is cool ]</p>');
 });
 
+test('bracketed statement with comment and blank lines', function() {
+  var emblem = w('div [',
+                 '  foo=bar',
+                 '',
+                 '  ',
+                 '  / We need to add more',
+                 ']');
+  compilesTo(
+    emblem, '<div foo={{bar}}></div>');
+});
+
+test('bracketed statement end bracket', function() {
+  var emblem = w('div [',
+                 '  foo=bar',
+                 '  ',
+                 '  data=baz ]');
+  compilesTo(
+    emblem, '<div foo={{bar}} data={{baz}}></div>');
+});
+
 test("nesting", function() {
   var emblem;
   emblem = "p class=\"hello\" data-foo=\"gnarly\"\n  span Yes";

--- a/tests/integration/glimmer-component-test.js
+++ b/tests/integration/glimmer-component-test.js
@@ -72,6 +72,16 @@ test('brackets with string', function(){
     emblem, '<my-component @foo={{bar}} @baz=\"food\"></my-component>');
 });
 
+test('brackets with dedent end', function(){
+  var emblem = w('',
+                 '%my-component [',
+                 '  @foo=bar',
+                 '  @baz=\'food\'',
+                 ']');
+  compilesTo(
+    emblem, '<my-component @foo={{bar}} @baz=\"food\"></my-component>');
+});
+
 // Invalid
 // test('brackets with positional params')
 

--- a/tests/integration/glimmer-component-test.js
+++ b/tests/integration/glimmer-component-test.js
@@ -78,6 +78,7 @@ test('brackets with string', function(){
 test('bracketed nested block', function(){
   var emblem = w('',
                  '%my-component [',
+                 '  ',
                  '  @something="false" ]',
                  '  p Bracketed helper attrs!');
   compilesTo(

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -365,6 +365,13 @@ test('bracketed nested block params with block', function(){
     emblem, '{{#sally \'foo\' something="false"}}<p>Bracketed helper attrs!</p>{{/sally}}');
 });
 
+test('bracketed statement with multiple initial arguments', function() {
+  var emblem = w('= component foo [',
+                 '  bar=baz',
+                 ']');
+  compilesTo(emblem, '{{component foo bar=baz}}');
+});
+
 test('bracketed nested block params', function(){
   var emblem = w('',
                  'sally [',

--- a/tests/integration/mustaches-test.js
+++ b/tests/integration/mustaches-test.js
@@ -334,9 +334,11 @@ test('explicit mustache with "/" in name', function(){
   compilesTo(emblem, '{{navigation/button-list}}');
 });
 
-test('bracketed statement with comment', function() {
+test('bracketed statement with comment and blank lines', function() {
   var emblem = w('sally [',
                  '  \'foo\'',
+                 '',
+                 '  ',
                  '  / We need to add more',
                  ']');
   compilesTo(


### PR DESCRIPTION
- Refactors `mustacheOrBlock` to separate out bracketed rules from basic nested
- Add blankline detection inside of bracketed mustache
- Add some additional tests for blank lines in HTML bracketed statements

Fixes #223 
Fixes #309 
Fixes #308 