### PR TITLE
Allow versions of handlebars >= 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=0.4.7"
   },
   "dependencies": {
-    "handlebars": "^2.0.0",
+    "handlebars": ">=2.0.0",
     "optimist": "^0.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Loosens up the requirements for `handlebars` versions.  Your readme says any version of handlebars should work, but the package.json would always only install a 2.x version, which have known security vulnerabilities.  This change allows the latest 4.x version to be used.