### PR TITLE
allow in-tag mustaches to precede multi-line start

### DIFF
--- a/lib/pegjs/html/tag-html.pegjs
+++ b/lib/pegjs/html/tag-html.pegjs
@@ -22,9 +22,9 @@ start = tagHtml
   This also needs to absorb comments for when using brackets
 */
 tagHtml
-= h:htmlStart __ '[' TERM* inTagMustaches:inTagMustache* fullAttributes:bracketedAttribute+ (_ inlineComment _ TERM)*
+= h:htmlStart startingInTagMustaches:inTagMustache* __ '[' TERM* inTagMustaches:inTagMustache* fullAttributes:bracketedAttribute+ (_ inlineComment _ TERM)*
 {
-  return parseInHtml(h, inTagMustaches, fullAttributes);
+  return parseInHtml(h, startingInTagMustaches.concat(inTagMustaches), fullAttributes);
 }
 / h:htmlStart inTagMustaches:inTagMustache* fullAttributes:attribute*
 {

--- a/tests/integration/mustache/html-attributes-test.js
+++ b/tests/integration/mustache/html-attributes-test.js
@@ -35,4 +35,14 @@ module('mustache: html attributes', function (hooks) {
   test("with doublestache", function (assert) {
     assert.compilesTo('p{{insertClass foo}} Hello', '<p {{insertClass foo}}>Hello</p>');
   });
+
+  test("with multi-line", function (assert) {
+    const emblem = w(
+      "div{did-insert this.handler} [",
+      "  class='test'",
+      "]",
+    );
+
+    assert.compilesTo(emblem, '<div {{did-insert this.handler}} class="test"></div>');
+  });
 });


### PR DESCRIPTION
Partially resolves #335. I'm new to peg.js so I'm not too sure this is the best way to implement this.